### PR TITLE
missing dev dependancies (babel-core, babel-loader)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "devDependencies": {
     "babel-core": "^6.24.1",
-    "babel-loader": "^6.4.1",
     "webpack": "^1.12.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "redux": "^3.3.1"
   },
   "devDependencies": {
+    "babel-core": "^6.24.1",
+    "babel-loader": "^6.4.1",
     "webpack": "^1.12.14"
   }
 }


### PR DESCRIPTION
babel-core and babel-loader are missing in the dev dependancies. these are needed to run `./node_modules/webpack/bin/webpack.js -d`